### PR TITLE
Fix: Remove unused jsPDF import

### DIFF
--- a/src/components/InputForm.js
+++ b/src/components/InputForm.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { jsPDF } from "jspdf";
 import { ChevronDown, Bot, RotateCcw, FileDown } from 'lucide-react';
 
 const SelectWrapper = ({ children }) => (


### PR DESCRIPTION
The import `import { jsPDF } from "jspdf";` in `src/components/InputForm.js` was causing a linting error during the Netlify build because it was not directly used. The `jsPDF` object was being accessed via `window.jspdf` instead.

This commit removes the unused import to resolve the build failure.